### PR TITLE
Reset unit after respawn

### DIFF
--- a/addons/@ocap/addons/ocap/functions/fn_addEventMission.sqf
+++ b/addons/@ocap/addons/ocap/functions/fn_addEventMission.sqf
@@ -10,6 +10,18 @@ addMissionEventHandler ["EntityKilled", {
 	_this call ocap_fnc_eh_killed;
 }];
 
+addMissionEventHandler ["EntityRespawned", {
+	params ["_entity", "_corpse"];
+
+	// Reset unit back to normal
+	_entity setvariable ["ocapIsKilled", false];
+
+	// Stop tracking old unit
+	if (_corpse getVariable ["ocap_isInitialised", false]) then {
+		_corpse setVariable ["ocap_exclude", true];
+	};
+}];
+
 call ocap_fnc_trackAceExplPlace;
 
 if (ocap_saveMissionEnded) then {


### PR DESCRIPTION
For what ever reason all variables on respawn will be copied to the new unit created.   
So we can just stop tracking the corpse and we are safe.

Example with reconnect:
http://162.55.178.211:5000/?file=2021_07_08__23_05_opt_v41.json&frame=0&zoom=9&x=-225.5439453125&y=123.009765625