### PR TITLE
Exclude unit when disconnected

### DIFF
--- a/addons/@ocap/addons/ocap/functions/fn_eh_disconnected.sqf
+++ b/addons/@ocap/addons/ocap/functions/fn_eh_disconnected.sqf
@@ -1,3 +1,9 @@
+params ["_unit", "_id", "_uid", "_name"];
+
 [":EVENT:",
-	[ocap_captureFrameNo, "disconnected", _this select 3]
+	[ocap_captureFrameNo, "disconnected", _name]
 ] call ocap_fnc_extension;
+
+if (_unit getVariable ["ocap_isInitialised", false]) then {
+	_unit setVariable ["ocap_exclude", true];
+};


### PR DESCRIPTION
Fixes https://github.com/OCAP2/OCAP/issues/38

This will cause that only units with a controller will be shown.
Currently dead units caused by disconnect will get [AI], this shouldn't be the case anymore.