### PR TITLE
Add option for manual capture start.

### DIFF
--- a/addons/@ocap/addons/ocap/config.cpp
+++ b/addons/@ocap/addons/ocap/config.cpp
@@ -33,10 +33,10 @@ class CfgFunctions
 		class null
 		{
 			file = "ocap\functions";
-			class init
-			{
-				preInit = 1;
-			};
+            class autostart {
+                preInit = 1;
+            };
+			class init{};
 			class addEventHandlers{};
 			class addEventMission{};
 			class eh_connected{};

--- a/addons/@ocap/addons/ocap/functions/fn_autoStart.sqf
+++ b/addons/@ocap/addons/ocap/functions/fn_autoStart.sqf
@@ -1,0 +1,27 @@
+/* ----------------------------------------------------------------------------
+Script: ocap_fnc_autoStart
+
+Description:
+    Run during preInit to check for auto or manual start. Calls ocap_fnc_init.
+
+Parameters:
+    None
+
+Returns:
+    Nothing
+
+Examples:
+    call ocap_fnc_autoStart;
+
+Public:
+    Yes
+
+Author:
+    TyroneMF
+---------------------------------------------------------------------------- */
+
+#include "\userconfig\ocap\config.hpp"
+
+if (ocap_autoStart) then {
+    [] call ocap_fnc_init;
+};

--- a/addons/@ocap/addons/ocap/functions/fn_init.sqf
+++ b/addons/@ocap/addons/ocap/functions/fn_init.sqf
@@ -2,7 +2,8 @@
 Script: ocap_fnc_init
 
 Description:
-	Run during preInit and used to start OCAP2 processes.
+	Automatic Start: Called from ocap_fnc_autoStart.
+	Manual Start: Server execution to begin.
 
 Parameters:
 	None

--- a/userconfig/ocap/config.hpp
+++ b/userconfig/ocap/config.hpp
@@ -1,3 +1,4 @@
+ocap_autoStart = true; // Automatically start OCAP recordings at session start.
 ocap_minPlayerCount = 15; // recording will only begin if this many players are in the server
 ocap_minMissionTime = 20; // missions must last at least this many minutes to be saved
 ocap_frameCaptureDelay = 1;


### PR DESCRIPTION
Adds an option to have it automatically begin on mission start (default) or allow it to be started manually.

Context:
My group as it is starts the mission 1 hour prior for people to hop on and get ready, this obviously would add an additional hour of recording we wouldn't necessarily want so this idea seems a pretty logical solution.

The default is always to autostart by calling `ocap_fnc_autoStart` in preInit and have that call `ocap_fnc_init`.

Tested both manual and automatic, works fine.