### PR TITLE
Add Enabled Administrator UI setting

### DIFF
--- a/x/ocap/addons/main/XEH_preInit.sqf
+++ b/x/ocap/addons/main/XEH_preInit.sqf
@@ -60,6 +60,31 @@ GVAR(allSettings) = [
   ],
 
   /*
+    CBA Setting: OCAP_enabledAdministratorUI
+    Description:
+      Turns on or off the Administrator UI in the briefing diary. Default: true
+
+    Setting Name:
+      Administrator UI Enabled
+
+    Value Type:
+      Boolean
+  */
+  [
+    QGVARMAIN(enabledAdministratorUI),
+    "CHECKBOX", // setting type
+    [
+      "Administrator UI Enabled", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+      "Turns on or off the Administrator UI in the briefing diary. Default: true"
+    ],
+    [COMPONENT_NAME, "Core"], // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    true, // default enabled
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {}, // function that will be executed once on mission start and every time the setting is changed.
+    false // requires restart to apply
+  ]
+
+  /*
     CBA Setting: OCAP_administratorList
     Description:
       An array or server-visible variable referencing one that is a list of playerUIDs. Additional briefing diary or UI elements may be available for more accessible control over OCAP's features. Takes effect on player server connection. Format: [] OR myAdminPUIDs | Default: []

--- a/x/ocap/addons/recorder/fnc_adminUIcontrol.sqf
+++ b/x/ocap/addons/recorder/fnc_adminUIcontrol.sqf
@@ -28,6 +28,8 @@
 
 #include "script_component.hpp"
 
+if (!GVARMAIN(enabledAdministratorUI)) exitWith {};
+
 params [
 	"_PID",
 	["_event", "", [""]]


### PR DESCRIPTION
Turns on or off the Administrator UI in the briefing diary. Useful for users with custom AAR frameworks in their missions/mods, persistence systems etc.

Admin UI will remain if setting is disabled during the mission, this could be handled but would require the setting to be in `recorder` component or an event being registered to handle the setting change in that component. As this is an admin tool, I consider it less important, but can be done if needed.

Alternative implementation would be to handle `ocap_administratorList = ""` (empty string indicating disabled), but this implementation is more clear and straightforward.