### PR TITLE
Fix Zero divisor error in Administrator UI on disconnect

### DIFF
--- a/x/ocap/addons/recorder/fnc_adminUIcontrol.sqf
+++ b/x/ocap/addons/recorder/fnc_adminUIcontrol.sqf
@@ -35,8 +35,8 @@ params [
 
 if (isNil "_PID") exitWith {};
 
-private _userInfo = (getUserInfo _PID);
-if (isNil "_userInfo") exitWith {};
+private _userInfo = getUserInfo _PID;
+if (_userInfo isEqualTo []) exitWith {};
 _userInfo params ["_playerID", "_owner", "_playerUID"];
 _unit = _userInfo select 10;
 

--- a/x/ocap/addons/recorder/fnc_eh_onUserAdminStateChanged.sqf
+++ b/x/ocap/addons/recorder/fnc_eh_onUserAdminStateChanged.sqf
@@ -27,10 +27,6 @@
 
 params ["_networkId", "_loggedIn", "_votedIn"];
 
-_userInfo = (getUserInfo _networkId);
-if (isNil "_userInfo") exitWith {};
-_object = _userInfo select 10;
-
 if (_loggedIn && !_votedIn) exitWith {
 	// if user has become admin by logging, not voting, trigger control addition check
 	[_networkId, "login"] call FUNC(adminUIcontrol);


### PR DESCRIPTION
Fixes Zero divisor error when an admin would disconnect.

> [`getUserInfo`](https://community.bistudio.com/wiki/getUserInfo)  Returns an empty array if said player is not found.

It can never return `nil` so check was switched to empty array check, which fixes this error.

Additionally cleaned up user info code in Event Handler for `OnUserAdminStateChanged` as variables were not actually used anywhere in the function and would also cause an error.