### PR TITLE
Compatibility with Restrict Markers

### DIFF
--- a/x/ocap/addons/recorder/fnc_handleMarkers.sqf
+++ b/x/ocap/addons/recorder/fnc_handleMarkers.sqf
@@ -175,6 +175,9 @@ EGVAR(listener,markers) = [QGVARMAIN(handleMarker), {
 
     if (!_local) exitWith {};
 
+    // If the Restrict Markers mod is loaded and enabled, only the server's markers should be recorded
+    if (GVAR(restrictMarkersCompat) && {!isServer}) exitWith {};
+
     // check for excluded values in marker name. if name contains at least one value, skip sending traffic to server
     // if value is undefined, then skip
     private _isExcluded = false;
@@ -225,6 +228,9 @@ EGVAR(listener,markers) = [QGVARMAIN(handleMarker), {
 
     if (!_local) exitWith {};
 
+    // If the Restrict Markers mod is loaded and enabled, only the server's markers should be recorded
+    if (GVAR(restrictMarkersCompat) && {!isServer}) exitWith {};
+
     // check for excluded values in marker name. if name contains at least one value, skip sending traffic to server
     // if value is undefined, then skip
     private _isExcluded = false;
@@ -256,6 +262,9 @@ EGVAR(listener,markers) = [QGVARMAIN(handleMarker), {
     params["_marker", "_local"];
 
     if (!_local) exitWith {};
+
+    // If the Restrict Markers mod is loaded and enabled, only the server's markers should be recorded
+    if (GVAR(restrictMarkersCompat) && {!isServer}) exitWith {};
 
     // check for excluded values in marker name. if name contains at least one value, skip sending traffic to server
     // if value is undefined, then skip

--- a/x/ocap/addons/recorder/fnc_init.sqf
+++ b/x/ocap/addons/recorder/fnc_init.sqf
@@ -95,6 +95,13 @@ publicVariable QGVARMAIN(version);
 EGVAR(extension,version) = ([":VERSION:", []] call EFUNC(extension,sendData));
 publicVariable QEGVAR(extension,version);
 
+/*
+  VARIABLE: OCAP_recorder_restrictMarkersCompat
+  Global variable flag to prevent a client's local markers from being recorded on the server, in the case of the mod Restrict Markers being loaded and enabled. Otherwise, marker recording would create lots of duplicates that hurt playback performance.
+*/
+EGVAR(recorder,restrictMarkersCompat) = isClass (configFile >> "CfgPatches" >> "restrict_markers") && {!isNil "restrict_markers_main_enabled" && {restrict_markers_main_enabled}};
+publicVariable QEGVAR(recorder,restrictMarkersCompat);
+
 // Add mission event handlers
 call FUNC(addEventMission);
 


### PR DESCRIPTION
The mod [Restrict Markers](https://steamcommunity.com/sharedfiles/filedetails/?id=3245243732) handles any received global marker and turns it into a local one on any client that is close enough to the creator. Internally it handles the markers of a dedicated server so that the server receives any created marker, but does not duplicate it if it is re-shared to others.

However, the re-sharing creates new local markers on clients, which are then recorded by OCAP events and sent to the server. This causes the server to record many duplicated markers, which harms playback performance.

My fix checks whether Restrict Markers is loaded and enabled on the server, and if so blocks any OCAP marker event on clients to be forwarded to the server.