### PR TITLE
fix(ace): gate ACE explosives placement on locality

### DIFF
--- a/addons/recorder/fnc_aceExplosives.sqf
+++ b/addons/recorder/fnc_aceExplosives.sqf
@@ -92,34 +92,41 @@ _explosive addEventHandler ["Deleted", {
   [QGVARMAIN(handlePlacedEvent), [_eventData]] call CBA_fnc_serverEvent;
 }];
 
-// Send :PLACED:CREATE: only from the placer. ace_explosives_place is a CBA
-// global event, so it fires on every machine — but on a dedicated server the
-// explosive's position has not yet network-synced (getPosASL returns 0,0,~0).
-// Only the machine that owns the object has the authoritative position at
-// this moment, matching the vanilla mine path in fnc_eh_fired_client.sqf.
-if (!local _explosive) exitWith {};
+// Send :PLACED:CREATE: from the server only — captureFrameNo and the placed-id
+// counter (GVAR(nextId)) live there, and the server is where the position
+// eventually syncs. Delay the read briefly: ace_explosives_place fires before
+// the explosive's position has settled on the server (getPosASL initially
+// returns 0,0,~0; correct after ~1s), which previously caused recordings to
+// show charges at the map origin.
+if (!isServer) exitWith {};
 
-// Resolve explosive metadata from config
-private _explType = typeOf _explosive;
-private _explosiveMag = getText(configFile >> "CfgAmmo" >> _explType >> "defaultMagazine");
-private _explosiveDisp = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "displayName");
-private _explosivePic = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "picture");
+[{
+  params ["_explosive", "_unit"];
+  if (isNull _explosive || {isNull _unit}) exitWith {};
 
-// Get placer's OCAP ID
-private _unitOcapId = _unit getVariable [QGVARMAIN(id), -1];
-if (_unitOcapId isEqualTo -1) exitWith {};
+  // Get placer's OCAP ID
+  private _unitOcapId = _unit getVariable [QGVARMAIN(id), -1];
+  if (_unitOcapId isEqualTo -1) exitWith {};
 
-// Build :PLACED:CREATE: data — same format as vanilla mines in fnc_eh_fired_client.sqf
-private _placedData = [
-  EGVAR(recorder,captureFrameNo),                                        // 0: captureFrameNo
-  -1,                                                                     // 1: placedId (assigned by server)
-  _explType,                                                              // 2: className
-  _explosiveDisp,                                                         // 3: displayName
-  (getPosASL _explosive) joinString ",",                                  // 4: position
-  _unitOcapId,                                                            // 5: firerOcapId
-  str (side group _unit),                                                 // 6: side
-  "put",                                                                  // 7: weapon
-  _explosivePic                                                           // 8: magazineIcon
-];
+  // Resolve explosive metadata from config
+  private _explType = typeOf _explosive;
+  private _explosiveMag = getText(configFile >> "CfgAmmo" >> _explType >> "defaultMagazine");
+  private _explosiveDisp = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "displayName");
+  private _explosivePic = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "picture");
 
-[QGVARMAIN(handlePlacedData), [_placedData, _explosive]] call CBA_fnc_serverEvent;
+  // Build :PLACED:CREATE: data — same format as vanilla mines in fnc_eh_fired_client.sqf
+  private _placedData = [
+    EGVAR(recorder,captureFrameNo),                                        // 0: captureFrameNo
+    -1,                                                                     // 1: placedId (assigned by server)
+    _explType,                                                              // 2: className
+    _explosiveDisp,                                                         // 3: displayName
+    (getPosASL _explosive) joinString ",",                                  // 4: position
+    _unitOcapId,                                                            // 5: firerOcapId
+    str (side group _unit),                                                 // 6: side
+    "put",                                                                  // 7: weapon
+    _explosivePic                                                           // 8: magazineIcon
+  ];
+
+  // handlePlacedData is registered server-side, so localEvent is sufficient
+  [QGVARMAIN(handlePlacedData), [_placedData, _explosive]] call CBA_fnc_localEvent;
+}, [_explosive, _unit], 1] call CBA_fnc_waitAndExecute;

--- a/addons/recorder/fnc_aceExplosives.sqf
+++ b/addons/recorder/fnc_aceExplosives.sqf
@@ -38,6 +38,14 @@ if (!SHOULDSAVEEVENTS) exitWith {};
 
 params ["_explosive", "_dir", "_pitch", "_unit"];
 
+// ace_explosives_place is a CBA global event — it fires on every machine. On a
+// dedicated server the explosive's position has not yet network-synced when the
+// event fires (getPosASL returns 0,0,~0). Only the placer (where the object is
+// local) has the authoritative position at this moment, so gate execution to it.
+// The placer then ships the data to the server via CBA_fnc_serverEvent below,
+// matching the vanilla mine path in fnc_eh_fired_client.sqf.
+if (!local _explosive) exitWith {};
+
 // Resolve explosive metadata from config
 private _explType = typeOf _explosive;
 private _explosiveMag = getText(configFile >> "CfgAmmo" >> _explType >> "defaultMagazine");

--- a/addons/recorder/fnc_aceExplosives.sqf
+++ b/addons/recorder/fnc_aceExplosives.sqf
@@ -38,42 +38,14 @@ if (!SHOULDSAVEEVENTS) exitWith {};
 
 params ["_explosive", "_dir", "_pitch", "_unit"];
 
-// ace_explosives_place is a CBA global event — it fires on every machine. On a
-// dedicated server the explosive's position has not yet network-synced when the
-// event fires (getPosASL returns 0,0,~0). Only the placer (where the object is
-// local) has the authoritative position at this moment, so gate execution to it.
-// The placer then ships the data to the server via CBA_fnc_serverEvent below,
-// matching the vanilla mine path in fnc_eh_fired_client.sqf.
-if (!local _explosive) exitWith {};
-
-// Resolve explosive metadata from config
-private _explType = typeOf _explosive;
-private _explosiveMag = getText(configFile >> "CfgAmmo" >> _explType >> "defaultMagazine");
-private _explosiveDisp = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "displayName");
-private _explosivePic = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "picture");
-
-// Get placer's OCAP ID
-private _unitOcapId = _unit getVariable [QGVARMAIN(id), -1];
-if (_unitOcapId isEqualTo -1) exitWith {};
-
 _explosive setVariable [QGVARMAIN(detonated), false];
 
-// Build :PLACED:CREATE: data — same format as vanilla mines in fnc_eh_fired_client.sqf
-private _placedData = [
-  EGVAR(recorder,captureFrameNo),                                        // 0: captureFrameNo
-  -1,                                                                     // 1: placedId (assigned by server)
-  _explType,                                                              // 2: className
-  _explosiveDisp,                                                         // 3: displayName
-  (getPosASL _explosive) joinString ",",                                  // 4: position
-  _unitOcapId,                                                            // 5: firerOcapId
-  str (side group _unit),                                                 // 6: side
-  "put",                                                                  // 7: weapon
-  _explosivePic                                                           // 8: magazineIcon
-];
-
-[QGVARMAIN(handlePlacedData), [_placedData, _explosive]] call CBA_fnc_serverEvent;
-
-// Attach lifecycle EHs — identical to vanilla path in fnc_eh_fired_client.sqf
+// Attach lifecycle EHs on every machine. addEventHandler is local, and the
+// EH only fires on the machine that owns the object at event-time, so
+// registering everywhere keeps tracking resilient to locality transfers
+// (e.g. placer disconnect → object transfers to server or another client).
+// The server-side polling in fnc_eh_fired_server.sqf is a secondary safety
+// net for the server-takeover case.
 _explosive addEventHandler ["HitExplosion", {
   params ["_explosive", "_hitEntity", "_explosiveOwner", "_hitThings"];
   if (isNull _hitEntity) exitWith {};
@@ -119,3 +91,35 @@ _explosive addEventHandler ["Deleted", {
   ];
   [QGVARMAIN(handlePlacedEvent), [_eventData]] call CBA_fnc_serverEvent;
 }];
+
+// Send :PLACED:CREATE: only from the placer. ace_explosives_place is a CBA
+// global event, so it fires on every machine — but on a dedicated server the
+// explosive's position has not yet network-synced (getPosASL returns 0,0,~0).
+// Only the machine that owns the object has the authoritative position at
+// this moment, matching the vanilla mine path in fnc_eh_fired_client.sqf.
+if (!local _explosive) exitWith {};
+
+// Resolve explosive metadata from config
+private _explType = typeOf _explosive;
+private _explosiveMag = getText(configFile >> "CfgAmmo" >> _explType >> "defaultMagazine");
+private _explosiveDisp = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "displayName");
+private _explosivePic = getText(configFile >> "CfgMagazines" >> _explosiveMag >> "picture");
+
+// Get placer's OCAP ID
+private _unitOcapId = _unit getVariable [QGVARMAIN(id), -1];
+if (_unitOcapId isEqualTo -1) exitWith {};
+
+// Build :PLACED:CREATE: data — same format as vanilla mines in fnc_eh_fired_client.sqf
+private _placedData = [
+  EGVAR(recorder,captureFrameNo),                                        // 0: captureFrameNo
+  -1,                                                                     // 1: placedId (assigned by server)
+  _explType,                                                              // 2: className
+  _explosiveDisp,                                                         // 3: displayName
+  (getPosASL _explosive) joinString ",",                                  // 4: position
+  _unitOcapId,                                                            // 5: firerOcapId
+  str (side group _unit),                                                 // 6: side
+  "put",                                                                  // 7: weapon
+  _explosivePic                                                           // 8: magazineIcon
+];
+
+[QGVARMAIN(handlePlacedData), [_placedData, _explosive]] call CBA_fnc_serverEvent;

--- a/addons/recorder/fnc_aceExplosives.sqf
+++ b/addons/recorder/fnc_aceExplosives.sqf
@@ -92,12 +92,11 @@ _explosive addEventHandler ["Deleted", {
   [QGVARMAIN(handlePlacedEvent), [_eventData]] call CBA_fnc_serverEvent;
 }];
 
-// Send :PLACED:CREATE: from the server only — captureFrameNo and the placed-id
-// counter (GVAR(nextId)) live there, and the server is where the position
-// eventually syncs. Delay the read briefly: ace_explosives_place fires before
-// the explosive's position has settled on the server (getPosASL initially
-// returns 0,0,~0; correct after ~1s), which previously caused recordings to
-// show charges at the map origin.
+// Send :PLACED:CREATE: from the server only, after a brief settle delay.
+// ace_explosives_place fires before the explosive's position has synced on
+// the server (getPosASL initially returns 0,0,~0; correct after ~1s), which
+// previously caused recordings to show charges at the map origin. Reading
+// after the delay on the server gives the authoritative settled position.
 if (!isServer) exitWith {};
 
 [{


### PR DESCRIPTION
## Summary
- ACE-placed explosives have been recorded at the map origin (0,0,0) on dedicated servers.
- Root cause: `ace_explosives_place` is a CBA *global* event, so the listener body ran on every machine. On a dedicated server the explosive's position is not yet network-synced when the event fires — `getPosASL` returns `0,0,~0`. The placer's client has the correct position immediately.
- Fix: gate execution on `local _explosive` so only the placer (which owns the object with the authoritative position) packages the data and forwards it via `CBA_fnc_serverEvent`. Same pattern as the vanilla mine path in `fnc_eh_fired_client.sqf`.

## Test plan
- [ ] Dedicated server: place an ACE explosive, confirm `:PLACED:CREATE:` arrives with the real position (not `0,0,...`).
- [ ] Hosted/SP: place an ACE explosive, confirm recording still captures it.
- [ ] Detonate/delete an existing ACE charge, confirm `:PLACED:EVENT:` `detonated`/`deleted` still fires (lifecycle EHs are added on the placer's machine, same machine that already ran them before this change).