### PR TITLE
fix(recorder): migrate FiredMan EH to new owner on locality transfer

### DIFF
--- a/addons/recorder/fnc_eh_fired_server.sqf
+++ b/addons/recorder/fnc_eh_fired_server.sqf
@@ -4,8 +4,13 @@
 // First, we'll remoteExec three functions to all clients:
 // eh_fired_client, eh_fired_clientBullet, and eh_fired_clientProjectile.
 
-// We'll use the Local EH to detect changes of unit locality. Add the EH for the soldier unit on the new owner, and remove it on the old. This EH only triggers on two machines so it limits the overall impact of doing so and validates duplicate records are not sent to the server.
-// https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#Local
+// We use a Local EH to detect locality changes and migrate the FiredMan/HandleDamage
+// handlers to follow the unit's owner. The Local EH only fires on machines where it
+// was added (https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#Local) — since
+// OCAP is server-side only, the EH lives on the server. When locality leaves the
+// server (e.g. a player slots into a pre-placed AI), the server must remoteExec the
+// install code to the new owner; otherwise the player's machine has no FiredMan EH
+// and their shots are never recorded.
 
 
 
@@ -28,8 +33,47 @@
 GVAR(trackedProjectiles) = createHashMap;
 GVAR(trackedPlacedObjects) = createHashMap;
 
+// Install block — adds the FiredMan/HandleDamage handlers on whichever machine
+// owns the unit. FUNC/QGVARMAIN macros are expanded here at compile time on the
+// server (the only machine with the PBO). When this code block is shipped to a
+// client via remoteExec ["call", ...], it carries the expanded global-variable
+// references; `ocap_recorder_fnc_eh_fired_client` is populated on every client by
+// the JIP remoteExec at the top of this file.
+GVAR(ownerInstallBlock) = {
+  private _id = _this addEventHandler ["FiredMan", {
+    private _start = diag_tickTime;
+    _this call FUNC(eh_fired_client);
+    TRACE_1("Ran fired handler",diag_tickTime - _start);
+  }];
+  _this setVariable [QGVARMAIN(firedManEHExists), true];
+  _this setVariable [QGVARMAIN(firedManEH), _id];
+
+  // HandleDamage stores the ammo classname on the victim for kill attribution
+  private _hdId = _this addEventHandler ["HandleDamage", {
+    params ["_unit", "", "", "", "_projectile"];
+    if (_projectile isNotEqualTo "" && {_projectile isNotEqualTo (_unit getVariable [QGVARMAIN(lastDamageAmmo), ""])}) then {
+      _unit setVariable [QGVARMAIN(lastDamageAmmo), _projectile, 2];
+    };
+  }];
+  _this setVariable [QGVARMAIN(handleDamageEHExists), true];
+  _this setVariable [QGVARMAIN(handleDamageEH), _hdId];
+};
+
+GVAR(ownerRemoveBlock) = {
+  if (_this getVariable [QGVARMAIN(firedManEHExists), false]) then {
+    _this removeEventHandler ["FiredMan", _this getVariable QGVARMAIN(firedManEH)];
+    _this setVariable [QGVARMAIN(firedManEHExists), false];
+    _this setVariable [QGVARMAIN(firedManEH), nil];
+  };
+  if (_this getVariable [QGVARMAIN(handleDamageEHExists), false]) then {
+    _this removeEventHandler ["HandleDamage", _this getVariable QGVARMAIN(handleDamageEH)];
+    _this setVariable [QGVARMAIN(handleDamageEHExists), false];
+    _this setVariable [QGVARMAIN(handleDamageEH), nil];
+  };
+};
+
 // Now we'll do the server setup.
-// Wrap everything in a CBA Class Event Handler so when the server initializes any soldier, it'll set up the Local EH. The Local EH is global (ironically) when applied to a unit so it'll do what we need across the entire session and trigger the relevant machines on locality change.
+// Wrap everything in a CBA Class Event Handler so when the server initializes any soldier, it'll set up the Local EH.
 ["CAManBase", "init", {
   params ["_entity"];
 
@@ -37,87 +81,28 @@ GVAR(trackedPlacedObjects) = createHashMap;
   // For local entities (server-owned AI), add directly — remoteExec to owner 0
   // (not-yet-networked entities) causes the object reference to deserialize as null.
   if (local _entity) then {
-    private _id = _entity addEventHandler ["FiredMan", {
-      private _start = diag_tickTime;
-      _this call FUNC(eh_fired_client);
-      TRACE_1("Ran fired handler",diag_tickTime - _start);
-    }];
-    _entity setVariable [QGVARMAIN(firedManEHExists), true];
-    _entity setVariable [QGVARMAIN(firedManEH), _id];
-
-    // HandleDamage stores the ammo classname on the victim for kill attribution
-    private _hdId = _entity addEventHandler ["HandleDamage", {
-      params ["_unit", "", "", "", "_projectile"];
-      if (_projectile isNotEqualTo "" && {_projectile isNotEqualTo (_unit getVariable [QGVARMAIN(lastDamageAmmo), ""])}) then {
-        _unit setVariable [QGVARMAIN(lastDamageAmmo), _projectile, 2];
-      };
-    }];
-    _entity setVariable [QGVARMAIN(handleDamageEHExists), true];
-    _entity setVariable [QGVARMAIN(handleDamageEH), _hdId];
+    _entity call GVAR(ownerInstallBlock);
   } else {
-    [_entity, {
-      private _id = _this addEventHandler ["FiredMan", {
-        private _start = diag_tickTime;
-        _this call FUNC(eh_fired_client);
-        TRACE_1("Ran fired handler",diag_tickTime - _start);
-      }];
-      _this setVariable [QGVARMAIN(firedManEHExists), true];
-      _this setVariable [QGVARMAIN(firedManEH), _id];
-
-      private _hdId = _this addEventHandler ["HandleDamage", {
-        params ["_unit", "", "", "", "_projectile"];
-        if (_projectile isNotEqualTo "" && {_projectile isNotEqualTo (_unit getVariable [QGVARMAIN(lastDamageAmmo), ""])}) then {
-          _unit setVariable [QGVARMAIN(lastDamageAmmo), _projectile, 2];
-        };
-      }];
-      _this setVariable [QGVARMAIN(handleDamageEHExists), true];
-      _this setVariable [QGVARMAIN(handleDamageEH), _hdId];
-    }] remoteExec ["call", owner _entity];
+    [_entity, GVAR(ownerInstallBlock)] remoteExec ["call", owner _entity];
   };
 
-
-  // Again, we will add a single Local EH for the unit on the server, but it has global effect so this is sufficient.
+  // Local EH on the server detects locality changes. Per BIS wiki, this EH only fires
+  // on machines where it was added — since clients don't have OCAP, the EH lives on
+  // the server only. We can't rely on a Local EH firing on the new owner: when the
+  // server loses locality (player slotting into pre-placed AI is the common case),
+  // we must remoteExec the install to the new owner. When the server regains locality
+  // (e.g. owner disconnect), we install directly here.
   _entity addEventHandler ["Local", {
-    // This code will be run on both the machine giving up ownership and the machine receiving ownership.
     params ["_entity", "_isLocal"];
 
-    // If the unit is NO LONGER local, remove the EH and the CBA EH.
-    // We need to see if it exists already.
-    private _firedManEHExists = _entity getVariable [QGVARMAIN(firedManEHExists), false];
-    private _handleDamageEHExists = _entity getVariable [QGVARMAIN(handleDamageEHExists), false];
-
-    // If the unit is NO LONGER local, and the EH exists, remove it.
-    if (!_isLocal && _firedManEHExists) then {
-      _entity removeEventHandler ["FiredMan", _entity getVariable QGVARMAIN(firedManEH)];
-      _entity setVariable [QGVARMAIN(firedManEHExists), false];
-      _entity setVariable [QGVARMAIN(firedManEH), nil];
-    };
-    if (!_isLocal && _handleDamageEHExists) then {
-      _entity removeEventHandler ["HandleDamage", _entity getVariable QGVARMAIN(handleDamageEH)];
-      _entity setVariable [QGVARMAIN(handleDamageEHExists), false];
-      _entity setVariable [QGVARMAIN(handleDamageEH), nil];
-    };
-
-    // If the unit is NOW local and the EH doesn't exist, add it.
-    if (_isLocal && !_firedManEHExists) then {
-      private _id = _entity addEventHandler ["FiredMan", {
-        TRACE_2("FiredMan EH fired",clientOwner,_this);
-        private _start = diag_tickTime;
-        _this call FUNC(eh_fired_client);
-        TRACE_1("Ran fired handler",diag_tickTime - _start);
-      }];
-      _entity setVariable [QGVARMAIN(firedManEHExists), true];
-      _entity setVariable [QGVARMAIN(firedManEH), _id];
-    };
-    if (_isLocal && !_handleDamageEHExists) then {
-      private _hdId = _entity addEventHandler ["HandleDamage", {
-        params ["_unit", "", "", "", "_projectile"];
-        if (_projectile isNotEqualTo "" && {_projectile isNotEqualTo (_unit getVariable [QGVARMAIN(lastDamageAmmo), ""])}) then {
-          _unit setVariable [QGVARMAIN(lastDamageAmmo), _projectile, 2];
-        };
-      }];
-      _entity setVariable [QGVARMAIN(handleDamageEHExists), true];
-      _entity setVariable [QGVARMAIN(handleDamageEH), _hdId];
+    if (_isLocal) then {
+      // Server gained locality — install on server directly.
+      _entity call GVAR(ownerInstallBlock);
+    } else {
+      // Server lost locality — clean up server EHs and install on the new owner.
+      // `owner _entity` returns the new owner at this point (locality has already changed).
+      _entity call GVAR(ownerRemoveBlock);
+      [_entity, GVAR(ownerInstallBlock)] remoteExec ["call", owner _entity];
     };
   }];
 

--- a/addons/recorder/fnc_eh_fired_server.sqf
+++ b/addons/recorder/fnc_eh_fired_server.sqf
@@ -40,6 +40,14 @@ GVAR(trackedPlacedObjects) = createHashMap;
 // references; `ocap_recorder_fnc_eh_fired_client` is populated on every client by
 // the JIP remoteExec at the top of this file.
 GVAR(ownerInstallBlock) = {
+  // Idempotent: clear any leftover EH from a previous ownership cycle before
+  // adding a new one. The server's Local EH cleanup runs server-side only, so
+  // a client that previously owned this unit still carries its old EH; if the
+  // unit returns to that client we would otherwise stack a second EH and emit
+  // duplicate :EVENT:PROJECTILE: records.
+  if (_this getVariable [QGVARMAIN(firedManEHExists), false]) then {
+    _this removeEventHandler ["FiredMan", _this getVariable QGVARMAIN(firedManEH)];
+  };
   private _id = _this addEventHandler ["FiredMan", {
     private _start = diag_tickTime;
     _this call FUNC(eh_fired_client);
@@ -49,6 +57,9 @@ GVAR(ownerInstallBlock) = {
   _this setVariable [QGVARMAIN(firedManEH), _id];
 
   // HandleDamage stores the ammo classname on the victim for kill attribution
+  if (_this getVariable [QGVARMAIN(handleDamageEHExists), false]) then {
+    _this removeEventHandler ["HandleDamage", _this getVariable QGVARMAIN(handleDamageEH)];
+  };
   private _hdId = _this addEventHandler ["HandleDamage", {
     params ["_unit", "", "", "", "_projectile"];
     if (_projectile isNotEqualTo "" && {_projectile isNotEqualTo (_unit getVariable [QGVARMAIN(lastDamageAmmo), ""])}) then {


### PR DESCRIPTION
## Summary
- Fix shots/hits not being recorded when a player slots into a pre-placed AI unit.
- Refactor the FiredMan/HandleDamage install/remove logic into reusable code values and trigger an install on the new owner whenever the server loses locality.

## Root cause
Per [BIS wiki](https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#Local), `addEventHandler "Local"` only fires on machines where it was added. OCAP is server-side only, so the Local EH lives on the server. The previous logic assumed the EH would fire on both old and new owners, but in practice:

1. Mission start: all pre-placed AI are server-local → FiredMan EH installed on server, Local EH installed on server.
2. Player joins and slots into AI: locality transfers server → player.
3. Server's Local EH fires with `_isLocal=false` → removes its own FiredMan EH.
4. Player's machine never had a Local EH → never installs FiredMan EH.
5. Player fires → no FiredMan EH → no `:EVENT:PROJECTILE:` ever reaches the extension.

This matched a user report where vehicle kills (server-side `EntityKilled`) and ACE3 medical events (server-local AI dying) were captured, but zero shots/hits were recorded across a 7-minute session with 10 confirmed kills.

## Fix
- Extract the install code into `GVAR(ownerInstallBlock)` and cleanup into `GVAR(ownerRemoveBlock)` to eliminate three near-duplicate copies.
- In the server's Local EH `_isLocal=false` branch, after cleaning up server EHs, `remoteExec` the install block to `owner _entity` (which is the new owner at that point).
- Update the misleading "Local EH is global (ironically)" comment to reflect actual semantics.

Delivery pattern is unchanged — install code is still shipped as an inline code block via `remoteExec ["call", target]`, just sourced from a `GVAR` instead of being inlined three times. No new `CfgRemoteExec` whitelisting required.

## Test plan
- [ ] In-game: player slots into a pre-placed AI unit, fires several rounds — verify `:EVENT:PROJECTILE:` events appear in the extension log at `loglevel: debug`.
- [ ] In-game: fresh player-owned unit (no AI takeover) fires — verify still works (regression check).
- [ ] In-game: kill a player, server takes locality back — verify FiredMan EH installs on server (existing path).
- [ ] In-game: AI hand-off between server and an HC — verify EH migrates.