### PR TITLE
feat: add variable name exclusion for objects

### DIFF
--- a/addons/recorder/XEH_preInit.sqf
+++ b/addons/recorder/XEH_preInit.sqf
@@ -211,7 +211,33 @@ GVAR(allSettings) = [
     false // requires restart to apply
   ],
 
+  /*
+    CBA Setting: OCAP_settings_excludeVarNameFromRecord
+    Description:
+      Array of vehicle variable names (vehicleVarName) that should be excluded from recording. Use single quotes! Default: []
 
+    Setting Name:
+      Variable Names to Exclude
+
+    Value Type:
+      Stringified Array
+
+    Example:
+      > "['hideout_1','cache_west']"
+  */
+  [
+    QEGVAR(settings,excludeVarNameFromRecord),
+    "EDITBOX", // setting type
+    [
+      "Variable Names to Exclude", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+      "Array of vehicle variable names (vehicleVarName) to exclude from recording. Use single quotes! Default: []"
+    ],
+    [COMPONENT_NAME, "Exclusions"], // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    "[]", // default string value
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {}, // function that will be executed once on mission start and every time the setting is changed.
+    false // requires restart to apply
+  ],
 
 
   // Section: Extra Tracking

--- a/addons/recorder/XEH_preInit.sqf
+++ b/addons/recorder/XEH_preInit.sqf
@@ -214,7 +214,7 @@ GVAR(allSettings) = [
   /*
     CBA Setting: OCAP_settings_excludeVarNameFromRecord
     Description:
-      Array of vehicle variable names (vehicleVarName) that should be excluded from recording. Use single quotes! Default: []
+      Array of editor variable names (vehicleVarName). Any unit or vehicle whose variable name matches will be excluded from recording. Matching is case-insensitive. Use single quotes! Default: []
 
     Setting Name:
       Variable Names to Exclude
@@ -230,7 +230,7 @@ GVAR(allSettings) = [
     "EDITBOX", // setting type
     [
       "Variable Names to Exclude", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-      "Array of vehicle variable names (vehicleVarName) to exclude from recording. Use single quotes! Default: []"
+      "Array of editor variable names (vehicleVarName) to exclude from recording. Case-insensitive. Use single quotes! Default: []"
     ],
     [COMPONENT_NAME, "Exclusions"], // Pretty name of the category where the setting can be found. Can be stringtable entry.
     "[]", // default string value
@@ -238,7 +238,6 @@ GVAR(allSettings) = [
     {}, // function that will be executed once on mission start and every time the setting is changed.
     false // requires restart to apply
   ],
-
 
   // Section: Extra Tracking
 

--- a/addons/recorder/fnc_captureLoop.sqf
+++ b/addons/recorder/fnc_captureLoop.sqf
@@ -98,7 +98,7 @@ GVAR(PFHObject) = [
           _x setVariable [QGVARMAIN(isInitialized), true, true];
         };
         // Check vehicleVarName against centralized exclude list
-        if (GVAR(excludeVarNameList) isNotEqualTo [] && {vehicleVarName _x in GVAR(excludeVarNameList)}) exitWith {
+        if (GVAR(excludeVarNameList) isNotEqualTo [] && {toLower (vehicleVarName _x) in GVAR(excludeVarNameList)}) exitWith {
           _x setVariable [QGVARMAIN(exclude), true, true];
           _x setVariable [QGVARMAIN(isInitialized), true, true];
         };
@@ -133,7 +133,9 @@ GVAR(PFHObject) = [
       };
       // Re-include units that have become player-controlled again (e.g., reconnected players)
       private _isExcluded = _x getVariable [QGVARMAIN(exclude), false];
-      if (_isExcluded && {isPlayer _x}) then {
+      // Only units that were actually recorded (have an ID) may be re-included, otherwise
+      // an intentionally excluded playable unit would be reported without ever being created.
+      if (_isExcluded && {isPlayer _x} && {(_x getVariable [QGVARMAIN(id), -1]) > -1}) then {
         _x setVariable [QGVARMAIN(exclude), false];
         _isExcluded = false;
       };
@@ -216,7 +218,7 @@ GVAR(PFHObject) = [
           _x setVariable [QGVARMAIN(isInitialized), true, true];
         };
         // Check vehicleVarName against centralized exclude list
-        if (GVAR(excludeVarNameList) isNotEqualTo [] && {vehicleVarName _x in GVAR(excludeVarNameList)}) exitWith {
+        if (GVAR(excludeVarNameList) isNotEqualTo [] && {toLower (vehicleVarName _x) in GVAR(excludeVarNameList)}) exitWith {
           _x setVariable [QGVARMAIN(exclude), true, true];
           _x setVariable [QGVARMAIN(isInitialized), true, true];
         };

--- a/addons/recorder/fnc_captureLoop.sqf
+++ b/addons/recorder/fnc_captureLoop.sqf
@@ -89,9 +89,16 @@ GVAR(PFHObject) = [
     {
       private _justInitialized = false;
       if !(_x getVariable [QGVARMAIN(isInitialized), false]) then {
-        if (
-          _x isKindOf "Logic"
-        ) exitWith {
+        if (_x isKindOf "Logic") exitWith {
+          _x setVariable [QGVARMAIN(exclude), true, true];
+          _x setVariable [QGVARMAIN(isInitialized), true, true];
+        };
+        // Check pre-set OCAP_main_exclude variable for per-object exclusion via editor init field
+        if (_x getVariable [QGVARMAIN(exclude), false]) exitWith {
+          _x setVariable [QGVARMAIN(isInitialized), true, true];
+        };
+        // Check vehicleVarName against centralized exclude list
+        if (GVAR(excludeVarNameList) isNotEqualTo [] && {vehicleVarName _x in GVAR(excludeVarNameList)}) exitWith {
           _x setVariable [QGVARMAIN(exclude), true, true];
           _x setVariable [QGVARMAIN(isInitialized), true, true];
         };
@@ -204,6 +211,15 @@ GVAR(PFHObject) = [
     {
       private _justInitialized = false;
       if !(_x getVariable [QGVARMAIN(isInitialized), false]) then {
+        // Check pre-set OCAP_main_exclude variable for per-object exclusion via editor init field
+        if (_x getVariable [QGVARMAIN(exclude), false]) exitWith {
+          _x setVariable [QGVARMAIN(isInitialized), true, true];
+        };
+        // Check vehicleVarName against centralized exclude list
+        if (GVAR(excludeVarNameList) isNotEqualTo [] && {vehicleVarName _x in GVAR(excludeVarNameList)}) exitWith {
+          _x setVariable [QGVARMAIN(exclude), true, true];
+          _x setVariable [QGVARMAIN(isInitialized), true, true];
+        };
         _vehType = typeOf _x;
         _class = _vehType call FUNC(getClass);
         private _vic = _x;

--- a/addons/recorder/fnc_init.sqf
+++ b/addons/recorder/fnc_init.sqf
@@ -86,8 +86,10 @@ GVAR(excludeMarkerList) = if (!isNil QEGVAR(settings,excludeMarkerFromRecord)) t
   []
 };
 
+// Lowercased once here so lookups in the capture loop can be case-insensitive,
+// matching how class/kind exclusions behave.
 GVAR(excludeVarNameList) = if (!isNil QEGVAR(settings,excludeVarNameFromRecord)) then {
-  parseSimpleArray EGVAR(settings,excludeVarNameFromRecord)
+  (parseSimpleArray EGVAR(settings,excludeVarNameFromRecord)) apply {toLower _x}
 } else {
   []
 };

--- a/addons/recorder/fnc_init.sqf
+++ b/addons/recorder/fnc_init.sqf
@@ -86,6 +86,12 @@ GVAR(excludeMarkerList) = if (!isNil QEGVAR(settings,excludeMarkerFromRecord)) t
   []
 };
 
+GVAR(excludeVarNameList) = if (!isNil QEGVAR(settings,excludeVarNameFromRecord)) then {
+  parseSimpleArray EGVAR(settings,excludeVarNameFromRecord)
+} else {
+  []
+};
+
 INFO_4("Settings snapshot — frameCaptureDelay: %1 | autoStart: %2 | minPlayerCount: %3 | minMissionTime: %4",GVAR(frameCaptureDelay),GVAR(autoStart),EGVAR(settings,minPlayerCount),GVAR(minMissionTime));
 
 GVAR(hasACEIsAwake) = !isNil "ace_common_fnc_isAwake";


### PR DESCRIPTION
## Summary

Adds the ability to exclude objects from OCAP recording by their editor **variable name** (`vehicleVarName`), complementing the existing classname, KindOf, and marker-prefix exclusions. This addresses a long-standing gap — mission makers previously had no way to hide specific objects from recording while keeping visible others of the same class.

## Changes

Three files modified:

### `addons/recorder/XEH_preInit.sqf`
- Registers new CBA setting `OCAP_settings_excludeVarNameFromRecord` under the existing **Exclusions** category
- Stringified array of `vehicleVarName` values, default `[]`

### `addons/recorder/fnc_init.sqf`
- Parses the new setting into `GVAR(excludeVarNameList)` at init

### `addons/recorder/fnc_captureLoop.sqf`
- Adds **two pre-initialization checks** in both the unit and vehicle capture paths, before any data is sent to the extension:

  1. **Per-object control** — honors `this setVariable ["OCAP_main_exclude", true, true]` pre-set in an object's editor init field. Objects with this variable set before OCAP encounters them are skipped entirely.
  2. **Centralized setting** — checks `vehicleVarName _x` against `OCAP_settings_excludeVarNameFromRecord`. Matching objects are fully excluded.

  Both checks exit early by marking `OCAP_main_isInitialized = true` (which prevents OCAP from re-processing them) and, for the centralized path, also mark `OCAP_main_exclude = true` for consistency with the rest of the exclusion system.

## How to Use

**Option A — Centralized** (in `description.ext` or server CBA settings):
```sqf
OCAP_settings_excludeVarNameFromRecord = "['hideout_alpha','cache_west']";
```

**Option B — Per-object** (in 3DEN init field):
```sqf
this setVariable ["OCAP_main_exclude", true, true];
```

## Use Case

Hidden insurgency hideouts that should not appear in AAR playback until later in a campaign. Place the object in the editor with a variable name, add it to the exclude list, then reconfigure or script the removal of the exclusion when the hideout should be revealed.