### PR TITLE
fix: admins missing UI controls when JIP joining

### DIFF
--- a/addons/recorder/XEH_prep.sqf
+++ b/addons/recorder/XEH_prep.sqf
@@ -19,6 +19,7 @@ PREP(addUnitEventHandlers);
 PREP(eh_connected);
 PREP(eh_disconnected);
 PREP(eh_onUserAdminStateChanged);
+PREP(eh_onUserSelectedPlayer);
 PREP(adminUIcontrol);
 
 PREP(eh_firedMan);

--- a/addons/recorder/fnc_addEventMission.sqf
+++ b/addons/recorder/fnc_addEventMission.sqf
@@ -53,6 +53,15 @@ if (isNil QEGVAR(EH,OnUserAdminStateChanged)) then {
   OCAPEXTLOG(["Initialized OnUserAdminStateChanged EH"]);
 };
 
+if (isNil QEGVAR(EH,OnUserSelectedPlayer)) then {
+  // Event Handler: OCAP_EH_OnUserSelectedPlayer
+  // Handle for the "OnUserSelectedPlayer" mission event handler. Fired when a player object is selected for user. Calls <OCAP_recorder_fnc_eh_onUserSelectedPlayer>.
+  EGVAR(EH,OnUserSelectedPlayer) = addMissionEventHandler ["OnUserSelectedPlayer", {
+    _this call FUNC(eh_onUserSelectedPlayer);
+  }];
+  OCAPEXTLOG(["Initialized OnUserSelectedPlayer EH"]);
+};
+
 if (isNil QEGVAR(EH,EntityKilled)) then {
   // Event Handler: OCAP_EH_EntityKilled
   // Handle for the "EntityKilled" mission event handler. Fired when an entity is killed. Calls <OCAP_recorder_fnc_eh_killed>.

--- a/addons/recorder/fnc_adminUIcontrol.sqf
+++ b/addons/recorder/fnc_adminUIcontrol.sqf
@@ -6,8 +6,8 @@
 	  Description:
 	    Runs checks to determine if a player should have the administrative diary entry added or removed upon joining the mission or logging in/out as admin.
 
-	    - <OCAP_recorder_fnc_eh_connected> at mission start to determine if a player is in <OCAP_administratorList>
 	    - <OCAP_recorder_fnc_eh_onUserAdminStateChanged> to add/remove when a player logs in or out as admin on the server
+	    - <OCAP_recorder_fnc_eh_onUserSelectedPlayer> at mission start to determine if a player is in <OCAP_administratorList>
 
 	  Parameters:
 	    _PID - PlayerID indicating unique network client on the server [String]

--- a/addons/recorder/fnc_eh_connected.sqf
+++ b/addons/recorder/fnc_eh_connected.sqf
@@ -7,8 +7,6 @@
 
     This function uses the <OCAP_EH_Connected> event handler to log "connected" events to the timeline.
 
-    It also calls <OCAP_recorder_fnc_adminUIControl> to apply the admin UI if the player is in <OCAP_administratorList>.
-
   Parameters:
     See the wiki for details. <https://community.bistudio.com/wiki/Arma_3:_Mission_Event_Handlers#PlayerConnected>
 
@@ -40,6 +38,3 @@ if (_owner isEqualTo 2) exitWith {};
     ["playerUid", _uid]
   ]] call CBA_fnc_encodeJSON
 ]] call EFUNC(extension,sendData);
-
-// trigger admin control check for all connecting players
-[_idstr, "connect"] call FUNC(adminUIcontrol);

--- a/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
+++ b/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
@@ -29,14 +29,22 @@
 params ["_networkId", "_playerObject"];
 
 // For non-JIP players, OnUserSelectedPlayer fires between preInit and postInit. Since we're initializing in postInit, this function will be too late to handle non-JIP players. Admins in this case are handled by <OCAP_recorder_fnc_init>.
-// In rare cases, _playerObject may be objNull despite Arma 3 v2.18 allowing the event to be postponed.
-if (isNull _playerObject) exitWith {
-	diag_log text format ["[OCAP] (recorder) WARNING: connecting player object is null for PID: %1", _networkId];
+if (!isNull _playerObject) exitWith {
+	_playerObject addEventHandler ["Local", {
+		params ["_playerObject"];
+		_playerObject removeEventHandler [_thisEvent, _thisEventHandler];
+
+		private _networkId = getPlayerID _playerObject;
+		[_networkId, "connect"] call FUNC(adminUIcontrol);
+	}];
 };
 
-_playerObject addEventHandler ["Local", {
-	params ["_playerObject"];
-	_playerObject removeEventHandler [_thisEvent, _thisEventHandler];
-	private _networkId = getPlayerID _playerObject;
-	[_networkId, "connect"] call FUNC(adminUIcontrol);
-}];
+// In rare cases, _playerObject may be objNull despite Arma 3 v2.18 allowing the event to be postponed.
+// Make a last ditch attempt to wait for the player object to be set (similar to <OCAP_recorder_fnc_init>).
+[{
+	!isNull (getUserInfo _this param [10, objNull, [objNull]])
+}, {
+	[_this, "connect"] call FUNC(adminUIcontrol);
+}, _networkId, 30, {
+	diag_log text format ["[OCAP] (recorder) WARNING: connecting player object is null for PID: %1", _networkId];
+}] call CBA_fnc_waitUntilAndExecute;

--- a/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
+++ b/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
@@ -28,6 +28,7 @@
 
 params ["_networkId", "_playerObject"];
 
+// Unlike PlayerConnected EH, this event does not fire for non-JIP players. Admins in this case are handled by <OCAP_recorder_fnc_init>.
 // In rare cases, _playerObject may be objNull despite Arma 3 v2.18 allowing the event to be postponed.
 if (isNull _playerObject) exitWith {
 	diag_log text format ["[OCAP] (recorder) WARNING: connecting player object is null for PID: %1", _networkId];

--- a/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
+++ b/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
@@ -1,0 +1,41 @@
+/* ----------------------------------------------------------------------------
+	FILE: fnc_eh_onUserSelectedPlayer.sqf
+
+	FUNCTION: OCAP_recorder_fnc_eh_onUserSelectedPlayer
+
+	Description:
+	  Uses <OCAP_EH_OnUserSelectedPlayer> to detect when someone joins the server.
+
+	  Calls <OCAP_recorder_fnc_adminUIControl> to apply the admin UI if the player is in <OCAP_administratorList>.
+
+	Parameters:
+	  _networkId - The network ID of the player who has logged in or out of the server [String]
+	  _playerObject - player object to be controlled by the user [Object]
+
+	Returns:
+	  Nothing
+
+	Examples:
+	  > call FUNC(eh_onUserSelectedPlayer);
+
+	Public:
+	  No
+
+	Author:
+	  IndigoFox
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params ["_networkId", "_playerObject"];
+
+// In rare cases, _playerObject may be objNull despite Arma 3 v2.18 allowing the event to be postponed.
+if (isNull _playerObject) exitWith {
+	diag_log text format ["[OCAP] (recorder) WARNING: connecting player object is null for PID: %1", _networkId];
+};
+
+_playerObject addEventHandler ["Local", {
+	params ["_playerObject"];
+	_playerObject removeEventHandler [_thisEvent, _thisEventHandler];
+	private _networkId = getPlayerID _playerObject;
+	[_networkId, "connect"] call FUNC(adminUIcontrol);
+}];

--- a/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
+++ b/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
@@ -28,7 +28,7 @@
 
 params ["_networkId", "_playerObject"];
 
-// Unlike PlayerConnected EH, this event does not fire for non-JIP players. Admins in this case are handled by <OCAP_recorder_fnc_init>.
+// For non-JIP players, OnUserSelectedPlayer fires between preInit and postInit. Since we're initializing in postInit, this function will be too late to handle non-JIP players. Admins in this case are handled by <OCAP_recorder_fnc_init>.
 // In rare cases, _playerObject may be objNull despite Arma 3 v2.18 allowing the event to be postponed.
 if (isNull _playerObject) exitWith {
 	diag_log text format ["[OCAP] (recorder) WARNING: connecting player object is null for PID: %1", _networkId];

--- a/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
+++ b/addons/recorder/fnc_eh_onUserSelectedPlayer.sqf
@@ -46,5 +46,5 @@ if (!isNull _playerObject) exitWith {
 }, {
 	[_this, "connect"] call FUNC(adminUIcontrol);
 }, _networkId, 30, {
-	diag_log text format ["[OCAP] (recorder) WARNING: connecting player object is null for PID: %1", _networkId];
+	diag_log text format ["[OCAP] (recorder) WARNING: connecting player object is null for PID: %1", _this];
 }] call CBA_fnc_waitUntilAndExecute;

--- a/addons/recorder/fnc_init.sqf
+++ b/addons/recorder/fnc_init.sqf
@@ -132,8 +132,7 @@ call FUNC(eh_fired_server);
 call FUNC(telemetryLoop);
 [] spawn FUNC(getStaticObjects);
 
-// Check already-connected players for admin controls (fixes race condition
-// where players connected before OCAP initialized don't get diary entries)
+// Check non-JIP players for admin controls, as postInit is too late for <OCAP_recorder_fnc_eh_onUserSelectedPlayer> to fire.
 // Wait for getUserInfo to be populated before calling, as it may not be ready during postInit
 {
   private _pid = getPlayerID _x;

--- a/addons/recorder/fnc_init.sqf
+++ b/addons/recorder/fnc_init.sqf
@@ -136,7 +136,7 @@ call FUNC(telemetryLoop);
 // where players connected before OCAP initialized don't get diary entries)
 // Wait for getUserInfo to be populated before calling, as it may not be ready during postInit
 {
-  private _pid = str owner _x;
+  private _pid = getPlayerID _x;
   [{
     private _info = getUserInfo _this;
     !isNil "_info" && {_info isEqualType [] && {count _info >= 11}}


### PR DESCRIPTION
Clients connecting to the server with their steam ID in the administrator list or logging in during the lobby don't receive the admin UI controls when joining a mission in progress.

Seemingly in this situation, the PlayerConnected mission EH fires before getUserInfo has a player object to return, resulting in the log:
> [OCAP] (recorder) WARNING: getUserInfo unit (index 10) is null for PID 1431421350 (UID: 7656...)

When backing out to the lobby and rejoining, i.e. not fully disconnecting from the server, the EH receives the player object and adds the controls as normal.

To solve this, an OnUserSelectedPlayer EH is added to wait until the player object exists and transfers locality:
https://community.bistudio.com/wiki/Arma_3:_Mission_Event_Handlers#OnUserSelectedPlayer
> This is the earliest the player object is known when player joins the server, but it is not local to the user yet, so there is a wait time depending on network connection.

Unlike PlayerConnected EH, OnUserSelectedPlayer does not fire for non-JIP players, so this would ironically break non-JIP admins. OCAP_recorder_fnc_init also documented an edge case where OCAP initialization may occur too late for the PlayerConnected EH to pick up non-JIP players, and so it calls adminUIcontrol there.

However, that code passed `str owner _x` to `getUserInfo` which expects a DirectPlayer ID, not a machine network ID. This fixes it to use the correct command, `getPlayerID`, so both JIP and non-JIP admins receive their controls.